### PR TITLE
fix(typings): add backslash to fromString @return type

### DIFF
--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -137,7 +137,7 @@ class Uuid
 	 *
 	 * @param string $uuid
 	 *
-	 * @return Ramsey\Uuid\UuidInterface
+	 * @return \Ramsey\Uuid\UuidInterface
 	 */
 	public function fromString(string $uuid)
 	{


### PR DESCRIPTION
Hello! I'm integrating [phpstan](https://github.com/phpstan/phpstan) to my project and I saw this typing issue. Just a missing backslash 🙂