### PR TITLE
fix(service): add return type for uuid service to satisfy phpstan

### DIFF
--- a/src/Config/Services.php
+++ b/src/Config/Services.php
@@ -5,6 +5,9 @@ use Michalsn\Uuid\Uuid;
 
 class Services extends BaseService
 {
+    /**
+     * @return Uuid
+     */
     public static function uuid(bool $getShared = true)
     {
 		if ($getShared)


### PR DESCRIPTION
Hey @michalsn,

I'm currently working on including the new [`phpstan-codeigniter` extension](https://github.com/CodeIgniter/phpstan-codeigniter) to [Castopod](https://github.com/ad-aures/castopod) and had `phpstan` complain because the `uuid` service is missing a return type:

```
Service method 'uuid' returns mixed.         
💡 Perhaps you forgot to add a return type?
```

Decided to set the return type in a docstring as I'm not sure it works as a return type in PHP 7.3

On another note, I think this project should not be supporting php 7.3 and even 7.4 as their EOL has passed. + CodeIgniter is in the talks about dropping a few deprecated versions as well! (https://github.com/codeigniter4/CodeIgniter4/issues/6921, https://github.com/codeigniter4/CodeIgniter4/issues/7320)

Thank you again for this library, I use it everywhere! 🙂