### PR TITLE
feat: add `fromValue()` to safely handle binary UUID strings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
   ],
   "require": {
     "php": ">=8.1",
-    "ramsey/uuid": "^4.7"
+    "ramsey/uuid": "^4.7",
+    "ext-ctype": "*"
   },
   "minimum-stability": "dev",
   "require-dev": {

--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -169,13 +169,13 @@ class Uuid
 	}
 
     /**
-     * Creates a representation from the provided value.
+     * From string or byte string to UUID object
      *
      * @param string $value The input value, which can be either a printable string or raw bytes.
      *
      * @return \Ramsey\Uuid\UuidInterface UUID interface.
      */
-    public function fromValue(string $value)
+    public function fromValue(string $value) : \Ramsey\Uuid\UuidInterface
     {
         if (ctype_print($value) === true)
         {

--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -168,6 +168,22 @@ class Uuid
 		return RamseyUuid::fromBytes($bytes);
 	}
 
+    /**
+     * Creates a representation from the provided value.
+     *
+     * @param string $value The input value, which can be either a printable string or raw bytes.
+     *
+     * @return \Ramsey\Uuid\UuidInterface UUID interface.
+     */
+    public function fromValue(string $value)
+    {
+        if (ctype_print($value) === true)
+        {
+            return $this->fromString($value);
+        }
+        return $this->fromBytes($value);
+    }
+
 	/**
 	 * From 128-bit integer string to UUID object
 	 *

--- a/src/UuidModel.php
+++ b/src/UuidModel.php
@@ -29,7 +29,7 @@ class UuidModel extends Model
 	 *
 	 * @var string
 	 */
-	protected $uuidVersion = 'uuid4';
+	protected $uuidVersion = 'uuid7';
 
 	/**
 	 * Store UUID in byte format.

--- a/src/UuidModel.php
+++ b/src/UuidModel.php
@@ -128,7 +128,7 @@ class UuidModel extends Model
 					continue;
 				}
 
-				$row[$field] = $this->uuid->fromBytes($row[$field])->toString();
+				$row[$field] = $this->uuid->fromValue($row[$field])->toString();
 			}
 			else
 			{
@@ -137,7 +137,7 @@ class UuidModel extends Model
 					continue;
 				}
 
-				$row->{$field} = $this->uuid->fromBytes($row->{$field})->toString();
+				$row->{$field} = $this->uuid->fromValue($row->{$field})->toString();
 			}
 		}
 
@@ -162,12 +162,12 @@ class UuidModel extends Model
 		{
 			foreach ($key as &$val)
 			{
-				$val = $this->uuid->fromString($val)->getBytes();
+				$val = $this->uuid->fromValue($val)->getBytes();
 			}
 		}
 		elseif (! empty($key))
 		{
-			$key = $this->uuid->fromString($key)->getBytes();
+			$key = $this->uuid->fromValue($key)->getBytes();
 		}
 
 		return $key;
@@ -221,7 +221,7 @@ class UuidModel extends Model
 				continue;
 			}
 
-			$row[$field] = $this->uuid->fromString($row[$field])->getBytes();
+			$row[$field] = $this->uuid->fromValue($row[$field])->getBytes();
 		}
 
 		return $row;
@@ -381,7 +381,7 @@ class UuidModel extends Model
 			// Convert UUID fields if needed
 			if ($val && in_array($key, $this->uuidFields) && $this->uuidUseBytes === true)
 			{
-				$val = ($this->uuid->fromString($val))->getBytes();
+				$val = ($this->uuid->fromValue($val))->getBytes();
 			}
 			
 			$builder->set($key, $val, $escape[$key] ?? null);
@@ -456,7 +456,7 @@ class UuidModel extends Model
 						{
 							if ($this->uuidUseBytes === true && ! empty($row[$field]))
 							{
-								$row[$field] = ($this->uuid->fromString($row[$field]))->getBytes();
+								$row[$field] = ($this->uuid->fromValue($row[$field]))->getBytes();
 							}
 						}
 					}
@@ -495,7 +495,7 @@ class UuidModel extends Model
 			// Convert UUID fields if needed
 			if ($val && in_array($key, $this->uuidFields) && $this->uuidUseBytes === true)
 			{
-				$val = ($this->uuid->fromString($val))->getBytes();
+				$val = ($this->uuid->fromValue($val))->getBytes();
 			}
 
 			$builder->set($key, $val, $escape[$key] ?? null);
@@ -528,7 +528,7 @@ class UuidModel extends Model
 				{
 					if (! empty($row[$field]))
 					{
-						$row[$field] = ($this->uuid->fromString($row[$field]))->getBytes();
+						$row[$field] = ($this->uuid->fromValue($row[$field]))->getBytes();
 					}
 				}
 			}

--- a/src/UuidModel.php
+++ b/src/UuidModel.php
@@ -29,7 +29,7 @@ class UuidModel extends Model
 	 *
 	 * @var string
 	 */
-	protected $uuidVersion = 'uuid7';
+	protected $uuidVersion = 'uuid4';
 
 	/**
 	 * Store UUID in byte format.

--- a/tests/UuidTest.php
+++ b/tests/UuidTest.php
@@ -148,4 +148,16 @@ class UuidTest extends CIUnitTestCase
         $result = $this->uuid->isValid('ff6f8cb0-0800200c9a66');
         $this->assertFalse($result);
     }
+
+    public function testFromValue()
+    {
+        $this->uuid = new Uuid($this->config);
+
+        $uuid = $this->uuid->fromValue('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
+        $bytes = $uuid->getBytes();
+
+        $fromBytesUuid = $this->uuid->fromValue($bytes);
+
+        $this->assertTrue($uuid->equals($fromBytesUuid));
+    }
 }


### PR DESCRIPTION
- Added method `Uuid::fromValue` - for automatic convert passed value to a UUID interface (from string or raw binary)
- Added test for new method
- Updated `UuidModel` - changed call `uuid->fromString(...)` \ `uuid->fromBytes(...)` to `uuid->fromValue(...)` - fix possible exceptions when the model tries to build a UUID from a string for a raw binary value.
- All tests passed