### PR TITLE
feat(uuid): add Base32 parsing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,9 @@ $uuid = service('uuid')->fromString('550e8400e29b41d4a716446655440000');
 // From ULID string
 $ulid = service('uuid')->fromString('01ARZ3NDEKTSV4RRFFQ69G5FAV');
 
+// From UUID Base32 encoding
+$uuid = service('uuid')->fromBase32('01JPRHWQCKFB7V1KMWP7PRRSMG');
+
 // From unknown format (string or binary)
 $uuid = service('uuid')->fromValue($unknownValue);
 ```

--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -48,6 +48,11 @@ class Uuid
         return new UuidWrapper(SymfonyUuid::fromBinary($value));
     }
 
+    public function fromBase32(string $uuid): UuidWrapper
+    {
+        return new UuidWrapper(SymfonyUuid::fromBase32($uuid));
+    }
+
     public function isValid(string $value): bool
     {
         // Check if it's a valid ULID

--- a/tests/UuidTest.php
+++ b/tests/UuidTest.php
@@ -8,6 +8,7 @@ use Michalsn\CodeIgniterUuid\Config\Uuid as UuidConfig;
 use Michalsn\CodeIgniterUuid\Enums\UuidVersion;
 use Michalsn\CodeIgniterUuid\Exceptions\CodeIgniterUuidException;
 use Michalsn\CodeIgniterUuid\Uuid;
+use Symfony\Component\Uid\Exception\InvalidArgumentException;
 use Symfony\Component\Uid\Ulid;
 use Symfony\Component\Uid\UuidV1;
 use Symfony\Component\Uid\UuidV3;
@@ -214,6 +215,33 @@ final class UuidTest extends TestCase
         $result = $this->uuid->fromValue($uuidString);
 
         $this->assertSame($uuid->toRfc4122(), $result->toRfc4122());
+    }
+
+    public function testFromBase32()
+    {
+        $uuid = $this->uuid->generate('v7');
+
+        $result = $this->uuid->fromBase32($uuid->toBase32());
+
+        $this->assertInstanceOf(UuidV7::class, $result->unwrap());
+        $this->assertSame($uuid->toRfc4122(), $result->toRfc4122());
+    }
+
+    public function testFromBase32WithLowercaseValue()
+    {
+        $uuid = $this->uuid->generate('v7');
+
+        $result = $this->uuid->fromBase32(strtolower($uuid->toBase32()));
+
+        $this->assertInstanceOf(UuidV7::class, $result->unwrap());
+        $this->assertSame($uuid->toRfc4122(), $result->toRfc4122());
+    }
+
+    public function testFromBase32WithInvalidValue()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->uuid->fromBase32('not-a-uuid');
     }
 
     public function testGenerateUlid()


### PR DESCRIPTION
**Description**
Added `Uuid::fromBase32()` as the matching parser for UUID values emitted with `UuidWrapper::toBase32()`.

The package already supports converting UUIDs to Base32, but there was no explicit package-level API for parsing that representation back into a UUID. `fromString()` also supports ULIDs, which share the same 26-character Crockford Base32 shape, so using a dedicated method makes the caller’s intent clear: parse this value as a UUID Base32 value.

This keeps Base32 UUID parsing available through the package API and avoids requiring application code to use the underlying Symfony UID classes directly.

Example:

```php
$uuid = service('uuid')->uuid7();
$base32 = $uuid->toBase32();
$parsed = service('uuid')->fromBase32($base32);
```

The change includes tests for uppercase input, lowercase input, and invalid input. The user guide was updated with a Base32 parsing example.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide